### PR TITLE
Generate Organizers' logged in Token

### DIFF
--- a/utils/auth.js
+++ b/utils/auth.js
@@ -6,11 +6,11 @@ const jwtSecret = config[env].jwtSecret;
 module.exports.checkAuth = (req, res, next) => {
   const token = req.body.token;
   if (!token) {
-    res.status(401).send('Unauthorized: No token provided');
+    res.status(401).json({success: false, message: 'Unauthorized: No token provided'});
   } else {
     jwt.verify(token, jwtSecret, function(err, payload) {
       if (err) {
-        res.status(401).send('Unauthorized: Invalid token');
+        res.status(401).json({success: false, message: 'Unauthorized: Invalid token'});
       } else {
         req.email = payload.email;
         req.usersId = payload.usersId;


### PR DESCRIPTION
**Dependency #1** 

### DONE
1. update `config.js` to make it more general
2. install `jsonwebtoken ` to generate jwt token as a proof that the user has logged in
3. in api `POST /api/login`, generate jwt token after the organizer has given the correct pair of email and password 
4. write a function `checkAuth` used to check whether the request can provide correct jwt token to execute the api
> a simple usage is in api `POST /api/event`
