### PR TITLE
need referral code when the user logs in

### DIFF
--- a/docker-dev.yml
+++ b/docker-dev.yml
@@ -6,7 +6,7 @@ services:
       - "dynamodb-dev-container"
     command: npm run dev-env
     volumes:
-      - .:/usr/app/
+      - .:/app/
       - /usr/app/node_modules
     ports:
       - "3010:3010"

--- a/src/controllers/accounts.controller.js
+++ b/src/controllers/accounts.controller.js
@@ -226,7 +226,12 @@ exports.login = async (req, res, next) => {
   const payload = {usersId: user.usersId, email: user.email};
   const token = auth.generateToken(payload);
   if (token) {
-    res.json(responseMsg.success({token, id: user.usersId, email: user.email}));
+    res.json(responseMsg.success({
+      token,
+      id: user.usersId,
+      email: user.email,
+      referralCode: response.data.referralCode,
+    }));
   } else {
     res.status(500).json(responseMsg.error(errorMsg.params.TOKEN,
         errorMsg.messages.TOKEN_SERVER_ERROR));

--- a/src/controllers/accounts.controller.js
+++ b/src/controllers/accounts.controller.js
@@ -230,7 +230,7 @@ exports.login = async (req, res, next) => {
       token,
       id: user.usersId,
       email: user.email,
-      referralCode: response.data.referralCode,
+      referralCode: user.referralCode,
     }));
   } else {
     res.status(500).json(responseMsg.error(errorMsg.params.TOKEN,

--- a/src/controllers/accounts.controller.js
+++ b/src/controllers/accounts.controller.js
@@ -148,7 +148,7 @@ exports.register = async (req, res, next) => {
 
   const payload = {email, sentAt: datetime.getUnixTimestamp()};
   const token = auth.generateToken(payload, '30d');
-  const url = `${reactServer}/activate-account?token=${token}`;
+  const url = `${reactServer}/activate-account?email=${email}&token=${token}`;
   sendMail(
       req.body.email,
       'Pinocchio - Verification Email',
@@ -283,7 +283,7 @@ exports.resendVerificationEmail = async (req, res, next) => {
     // not verified; resend verification email
     const payload = {email, sentAt: datetime.getUnixTimestamp()};
     const token = auth.generateToken(payload, '30d');
-    const url = `${reactServer}/activate-account?token=${token}`;
+    const url = `${reactServer}/activate-account?email=${email}&token=${token}`;
     // TODO: D.R.Y. Same as the sendMail in register API
     sendMail(
         email,


### PR DESCRIPTION
### For frontend usage XD
1. when login api is called, it should return referral code. 
2. when sending verification email to organizers, it should also append `email` info in the url. So that when the token expires, frontend can request which specific email to resend verification email to 