### PR TITLE
generate test coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ package-lock.json
 config.js
 .idea/
 debug
+
+// for generating test coverage output
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "load-test-data": "node src/tests/testData/loadData.js",
     "delete-tables": "node src/dynamodb/deleteTables.js",
     "test": "NODE_ENV=test source run_tests.sh",
+    "coverage": "nyc --reporter text npm test",
     "awstest": "NODE_ENV=awstest node ./server.js"
   },
   "repository": {
@@ -47,6 +48,7 @@
     "moment": "^2.24.0",
     "node-geocoder": "^3.23.0",
     "nodemailer": "^6.2.1",
+    "nyc": "^14.1.1",
     "swagger-jsdoc": "^3.3.0",
     "swagger-ui-express": "^4.0.7",
     "uuid": "^3.3.2",


### PR DESCRIPTION
### Prerequisite
- run `npm install` to install `nyc`

### Completed
- when you run `npm run coverage`, it calculates test coverage for all files and generate a table. 
![image](https://user-images.githubusercontent.com/5423351/64452196-db640780-d0b3-11e9-9efa-f5b17d37f2e6.png)
