### PR TITLE
Feature aws transcribe

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -20,6 +20,28 @@ const dev = {
     apiKey: ''
   },
   swaggerURL: 'localhost:3010',
+  // TODO: combine dynamodb/transcribe config
+  awsConfig: {
+    accessKeyId: '',
+    secretAccessKey: '',
+    region: 'us-east-1'
+  },
+  awsS3: {
+    uploadBucket: 'pinocchio-data61-audio',
+    endpoint: 'https://s3.us-east-1.amazonaws.com'
+  },
+  awsTranscribeConfig: {
+    endpoint: 'https://transcribe.us-east-1.amazonaws.com'
+  },
+  awsTranscriptionJob: {
+    LanguageCode: 'en-US',
+    MediaFormat: 'mp3',
+    TranscriptionJobName: '',
+    Media: {
+      MediaFileUri: ''
+    },
+    OutputBucketName: 'pinocchio-data61-transcriptions'
+  },
   // SmartContract related
   providerURI: 'http://127.0.0.1:7545',
   publicKey: '0x976bcD111D081c50E70D8e51f27E1E08782E73cD',

--- a/config.sample.js
+++ b/config.sample.js
@@ -26,24 +26,24 @@ const dev = {
     secretAccessKey: '',
     region: 'us-east-1'
    },
-   awsS3: {
+  awsS3: {
     uploadBucket: 'pinocchio-data61-audio',
     domain: 's3.us-east-1.amazonaws.com',
     protocol: 'https'
-   },
-   awsTranscribeConfig: {
-     domain: 'transcribe.us-east-1.amazonaws.com',
-     protocol: 'https'
-   },
-   awsTranscriptionJob: {
-     LanguageCode: 'en-US',
-     MediaFormat: 'mp3',
-     TranscriptionJobName: '',
-     Media: {
-       MediaFileUri: ''
-     },
-     OutputBucketName: 'pinocchio-data61-transcriptions'
-   },
+  },
+  awsTranscribeConfig: {
+    domain: 'transcribe.us-east-1.amazonaws.com',
+    protocol: 'https'
+  },
+  awsTranscriptionJob: {
+    LanguageCode: 'en-US',
+    MediaFormat: 'mp3',
+    TranscriptionJobName: '',
+    Media: {
+      MediaFileUri: ''
+    },
+    OutputBucketName: 'pinocchio-data61-transcriptions'
+  },
   // SmartContract related
   providerURI: 'http://127.0.0.1:7545',
   publicKey: '0x976bcD111D081c50E70D8e51f27E1E08782E73cD',

--- a/config.sample.js
+++ b/config.sample.js
@@ -25,23 +25,25 @@ const dev = {
     accessKeyId: '',
     secretAccessKey: '',
     region: 'us-east-1'
-  },
-  awsS3: {
+   },
+   awsS3: {
     uploadBucket: 'pinocchio-data61-audio',
-    endpoint: 'https://s3.us-east-1.amazonaws.com'
-  },
-  awsTranscribeConfig: {
-    endpoint: 'https://transcribe.us-east-1.amazonaws.com'
-  },
-  awsTranscriptionJob: {
-    LanguageCode: 'en-US',
-    MediaFormat: 'mp3',
-    TranscriptionJobName: '',
-    Media: {
-      MediaFileUri: ''
-    },
-    OutputBucketName: 'pinocchio-data61-transcriptions'
-  },
+    domain: 's3.us-east-1.amazonaws.com',
+    protocol: 'https'
+   },
+   awsTranscribeConfig: {
+     domain: 'transcribe.us-east-1.amazonaws.com',
+     protocol: 'https'
+   },
+   awsTranscriptionJob: {
+     LanguageCode: 'en-US',
+     MediaFormat: 'mp3',
+     TranscriptionJobName: '',
+     Media: {
+       MediaFileUri: ''
+     },
+     OutputBucketName: 'pinocchio-data61-transcriptions'
+   },
   // SmartContract related
   providerURI: 'http://127.0.0.1:7545',
   publicKey: '0x976bcD111D081c50E70D8e51f27E1E08782E73cD',

--- a/docker-dev.yml
+++ b/docker-dev.yml
@@ -6,7 +6,7 @@ services:
       - "dynamodb-dev-container"
     command: npm run dev-env
     volumes:
-      - .:/app/
+      - .:/app
       - /app/node_modules
     ports:
       - "3010:3010"

--- a/docker-test.yml
+++ b/docker-test.yml
@@ -6,7 +6,7 @@ services:
       - "dynamodb-test-container"
     command: npm run test-env
     volumes:
-      - .:/app/
+      - .:/app
       - /app/node_modules
     ports:
       - "3020:3010"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "chai-http": "^4.3.0",
     "ethereumjs-tx": "^2.1.0",
     "express": "^4.17.1",
+    "express-fileupload": "^1.1.5",
     "express-validator": "^6.1.0",
     "jquery-csv": "^1.0.3",
     "jsonwebtoken": "^8.5.1",

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ starts server on port 3010
 */
 
 const express = require('express');
+const fileUpload = require('express-fileupload');
 const bodyParser = require('body-parser');
 const swaggerJSDoc = require('swagger-jsdoc');
 const swaggerUi = require('swagger-ui-express');
@@ -57,6 +58,9 @@ app.use(bodyParser.json());
 
 // parse application/x-www-form-urlencoded
 app.use(bodyParser.urlencoded({extended: true}));
+
+// handle file uploads
+app.use(fileUpload());
 
 // allow cross origin requests (CORS)
 app.use(function(req, res, next) {

--- a/src/controllers/events.controller.js
+++ b/src/controllers/events.controller.js
@@ -209,7 +209,7 @@ exports.get = async (req, res) => {
     const event = eventExists.data[0];
     const ret = {
       id: event.eventsId, name: event.name,
-      status: event.status, address: event.address,
+      status: event.eventStatus, address: event.address,
     };
     return res.json(responseMsg.success({event: ret}));
   } else {
@@ -291,8 +291,7 @@ exports.upload = async (req, res, next) => {
 
     // get event transcripts
     const eventTranscripts = event.transcripts;
-
-    const fileList = req.files.file;
+    const fileList = Array.isArray(req.files.file) ? req.files.file : [req.files.file];
 
     // upload all files in request
     // this design will upload all files that are not

--- a/src/controllers/events.controller.js
+++ b/src/controllers/events.controller.js
@@ -3,6 +3,7 @@ controller for events
 */
 
 const dynamoDb = require('../models/dynamoDbWrapper.js');
+const transcribe = require('../transcribe/transcription.js');
 
 // validators
 const {check, validationResult} = require('express-validator');
@@ -46,12 +47,18 @@ exports.validate = (method) => {
       return [
         check('eventsId').trim().isLength({min: 1}),
         check('eventStatus').trim().isLength({min: 1}),
-       ];
+      ];
     }
     case 'get': {
       // TODO: check whether it's attendable
       return [
         check('eventsId').trim().isLength({min: 1}),
+      ];
+    }
+    case 'upload': {
+      return [
+        check('eventsId').trim().isLength({min: 1}),
+        check('file').trim().isLength({min: 1}),
       ];
     }
   }
@@ -187,28 +194,28 @@ exports.verifyLocation = async (req, res, next) => {
 };
 
 exports.get = async (req, res) => {
-    // check whether inputs are valid
-    const validation = validationResult(req);
-    if (!validation.isEmpty()) {
-      return res.status(422).json(responseMsg.validationError422(validation.errors));
-    }
-    const {eventsId} = req.query;
-    const eventExists = await dynamoDb.getEvents(eventsId);
-    if (!eventExists.success) {
-      return res.status(500).json(eventExists);
-    } else if (eventExists.data.length > 0) {
-      const event = eventExists.data[0];
-      const ret = {
-        id: event.eventsId, name: event.name,
-        status: event.status, address: event.address,
-      };
-      return res.json(responseMsg.success({event: ret}));
-    } else {
-      // event doesnt exist
-      return res.status(422).json(responseMsg.error(errorMsg.params.EVENTID,
-          errorMsg.messages.EVENT_NOT_FOUND));
-    }
-  };
+  // check whether inputs are valid
+  const validation = validationResult(req);
+  if (!validation.isEmpty()) {
+    return res.status(422).json(responseMsg.validationError422(validation.errors));
+  }
+  const {eventsId} = req.query;
+  const eventExists = await dynamoDb.getEvents(eventsId);
+  if (!eventExists.success) {
+    return res.status(500).json(eventExists);
+  } else if (eventExists.data.length > 0) {
+    const event = eventExists.data[0];
+    const ret = {
+      id: event.eventsId, name: event.name,
+      status: event.status, address: event.address,
+    };
+    return res.json(responseMsg.success({event: ret}));
+  } else {
+    // event doesnt exist
+    return res.status(422).json(responseMsg.error(errorMsg.params.EVENTID,
+        errorMsg.messages.EVENT_NOT_FOUND));
+  }
+};
 
 // update event status
 exports.status = async (req, res, next) => {
@@ -217,7 +224,7 @@ exports.status = async (req, res, next) => {
   if (!validation.isEmpty()) {
     return res.status(422).json(responseMsg.validationError422(validation.errors));
   }
-  
+
   const {eventsId, eventStatus} = req.body;
   const validStatuses = Object.values(eventStatuses);
   if (validStatuses.indexOf(eventStatus) == -1) {
@@ -255,4 +262,12 @@ exports.status = async (req, res, next) => {
     return res.status(422).json(responseMsg.error(errorMsg.params.EVENTID,
         errorMsg.messages.EVENT_NOT_FOUND));
   }
+};
+
+// upload event audio to s3
+exports.upload = async (req, res, next) => {
+  // const {eventsId, file} = req.body;
+  const {file} = req.body;
+  transcribe.startTranscription(file);
+  return res.json(responseMsg.success({}));
 };

--- a/src/controllers/events.controller.js
+++ b/src/controllers/events.controller.js
@@ -3,7 +3,8 @@ controller for events
 */
 
 const dynamoDb = require('../models/dynamoDbWrapper.js');
-const transcribe = require('../transcribe/transcription.js');
+// const transcribe = require('../utils/transcription.js');
+const s3 = require('../utils/s3.js');
 
 // validators
 const {check, validationResult} = require('express-validator');
@@ -267,7 +268,12 @@ exports.status = async (req, res, next) => {
 // upload event audio to s3
 exports.upload = async (req, res, next) => {
   // const {eventsId, file} = req.body;
-  const {file} = req.body;
-  transcribe.startTranscription(file);
+  console.log(req.body);
+  console.log(req.files);
+
+  s3.s3Upload(req.files.file.name, req.body.eventsId, req.files.file.data);
+
+  // const {file} = req.body;
+  // transcribe.startTranscription(file);
   return res.json(responseMsg.success({}));
 };

--- a/src/controllers/events.controller.js
+++ b/src/controllers/events.controller.js
@@ -273,16 +273,22 @@ exports.upload = async (req, res, next) => {
 
   s3.s3Upload(filename, eventsId, fileData)
       .then((data) => {
-      // upload successful and start transcription
+        // upload successful and start transcription
         const fileLoaction = data['Location'];
-        transcribe.startTranscription(fileLoaction);
-        return res.json(responseMsg.success({}));
+        transcribe.startTranscription(fileLoaction)
+            .then((_) => {
+              // transcription job started successfully
+              return res.json(responseMsg.success({}));
+            })
+            .catch((_) => {
+              // transcription service error
+              return res.status(500).json(responseMsg.error(errorMsg.params.TRANSCRIBESERVICE,
+                  errorMsg.messages.AWS_SERVICE_ERROR));
+            });
       })
       .catch((_) => {
-        return res.status(500).json(responseMsg.error(errorMsg.params.AWSSERVER,
+      // s3 service error
+        return res.status(500).json(responseMsg.error(errorMsg.params.S3SERVICE,
             errorMsg.messages.AWS_SERVICE_ERROR));
       });
-  // console.log(s3UploadResult);
-
-  // return res.json(responseMsg.success({}));
 };

--- a/src/controllers/events.controller.js
+++ b/src/controllers/events.controller.js
@@ -295,6 +295,8 @@ exports.upload = async (req, res, next) => {
     const fileList = req.files.file;
 
     // upload all files in request
+    // this design will upload all files that are not
+    // duplicate transcript filenames (regardless of order)
     const duplicateFiles = [];
     const uploadedFiles = [];
     for (const file of fileList) {

--- a/src/controllers/events.controller.js
+++ b/src/controllers/events.controller.js
@@ -3,7 +3,6 @@ controller for events
 */
 
 const dynamoDb = require('../models/dynamoDbWrapper.js');
-// const transcribe = require('../utils/transcription.js');
 const s3 = require('../utils/s3.js');
 
 // validators
@@ -267,13 +266,12 @@ exports.status = async (req, res, next) => {
 
 // upload event audio to s3
 exports.upload = async (req, res, next) => {
-  // const {eventsId, file} = req.body;
-  console.log(req.body);
-  console.log(req.files);
+  const filename = req.files.file.name;
+  const fileData = req.files.file.data;
+  const {eventsId} = req.body;
 
-  s3.s3Upload(req.files.file.name, req.body.eventsId, req.files.file.data);
+  const s3UploadResult = await s3.s3Upload(filename, eventsId, fileData);
+  console.log(s3UploadResult);
 
-  // const {file} = req.body;
-  // transcribe.startTranscription(file);
   return res.json(responseMsg.success({}));
 };

--- a/src/models/dynamoDbWrapper.js
+++ b/src/models/dynamoDbWrapper.js
@@ -160,11 +160,11 @@ module.exports.updateVerified = async (usersId, email, datetime) => {
   return await this.updateData('usersTable', args);
 };
 
-module.exports.updateEventStatus = async (eventsId, organizerId, eventStatus) => {
+module.exports.updateEvent = async (eventsId, organizerId, key, value) => {
   const args = {
     Key: {eventsId, organizerId},
-    UpdateExpression: 'set eventStatus = :s',
-    ExpressionAttributeValues: {':s': eventStatus},
+    UpdateExpression: `set ${key} = :s`,
+    ExpressionAttributeValues: {':s': value},
     ReturnValues: 'UPDATED_NEW',
   };
   return await this.updateData('eventsTable', args);

--- a/src/routes/events.router.js
+++ b/src/routes/events.router.js
@@ -145,7 +145,7 @@ module.exports = (app) => {
      *
      */
 
-    app.get('/api/event', events.validate('get'), events.get);
+  app.get('/api/event', events.validate('get'), events.get);
 
   /**
      * @swagger
@@ -177,4 +177,35 @@ module.exports = (app) => {
      */
 
   app.post('/api/events/status', events.validate('status'), events.status);
+
+  /**
+     * @swagger
+     * /api/events/upload:
+     *  post:
+     *      tags:
+     *          - Events
+     *      name: upload mp3 file
+     *      summary: upload event audio
+     *      produces:
+     *          - application/json
+     *      consumes:
+     *          - application/x-www-form-urlencoded
+     *      parameters:
+     *          - name: eventsId
+     *            type: string
+     *            minLength: 1
+     *            in: formData
+     *          - name: file
+     *            type: object
+     *            minLength: 1
+     *            in: formData
+     *      responses:
+     *          '200':
+     *              description: The event audio was successfully uploaded
+     *          '422':
+     *              description: invalid parameters or eventsId does not exist
+     *
+     */
+
+  app.post('/api/events/upload', events.validate('upload'), events.upload);
 };

--- a/src/tests/testData/csvs/eventTestData.csv
+++ b/src/tests/testData/csvs/eventTestData.csv
@@ -1,5 +1,5 @@
-name,eventsId,organizerId,attendees,type,address,city,zipcode,state,promotionUrl,latitude,longitude,eventStatus
-Brock Battle,0.5472598822772001,0.586753295452001,12,speech,Pewter Gym,Pewter City,07474,Kanto,https://bulbapedia.bulbagarden.net/wiki/Pewter_Gym,34.1397,118.0353,pending
-Misty Battle,0.5472598822772002,0.586753295452001,15,speech,Cerulean Gym,Cerulean City,121121,Kanto,https://bulbapedia.bulbagarden.net/wiki/Cerulean_Gym,34.1397,118.0353,pending
-Lt. Surge Battle,0.5472598822772003,0.586753295452001,20,speech,Vermilion Gym,Vermilion City,02626,Kanto,https://bulbapedia.bulbagarden.net/wiki/Vermilion_Gym,34.1397,118.0353,pending
-MSELi Event,0.1442598822772001,0.586753295452144,35,speech,300 S. Craig Street,Pittsburgh,15213,Pennsylvania,https://mse.isri.cmu.edu,40.445609,-79.9489984,pending
+name,eventsId,organizerId,attendees,type,address,city,zipcode,state,promotionUrl,latitude,longitude,eventStatus,transcripts
+Brock Battle,0.5472598822772001,0.586753295452001,12,speech,Pewter Gym,Pewter City,07474,Kanto,https://bulbapedia.bulbagarden.net/wiki/Pewter_Gym,34.1397,118.0353,pending,{}
+Misty Battle,0.5472598822772002,0.586753295452001,15,speech,Cerulean Gym,Cerulean City,121121,Kanto,https://bulbapedia.bulbagarden.net/wiki/Cerulean_Gym,34.1397,118.0353,pending,{}
+Lt. Surge Battle,0.5472598822772003,0.586753295452001,20,speech,Vermilion Gym,Vermilion City,02626,Kanto,https://bulbapedia.bulbagarden.net/wiki/Vermilion_Gym,34.1397,118.0353,pending,{}
+MSELi Event,0.1442598822772001,0.586753295452144,35,speech,300 S. Craig Street,Pittsburgh,15213,Pennsylvania,https://mse.isri.cmu.edu,40.445609,-79.9489984,pending,{}

--- a/src/tests/testData/jsons/eventsTestData.json
+++ b/src/tests/testData/jsons/eventsTestData.json
@@ -36,6 +36,9 @@
                         },
                         "status": {
                             "S": "pending"
+                        },
+                        "transcripts": {
+                            "M": {}
                         }
                     }
                 }
@@ -75,6 +78,9 @@
                         },
                         "status": {
                             "S": "pending"
+                        },
+                        "transcripts": {
+                            "M": {}
                         }
                     }
                 }
@@ -114,6 +120,9 @@
                         },
                         "status": {
                             "S": "pending"
+                        },
+                        "transcripts": {
+                            "M": {}
                         }
                     }
                 }
@@ -153,6 +162,9 @@
                         },
                         "status": {
                             "S": "pending"
+                        },
+                        "transcripts": {
+                            "M": {}
                         }
                     }
                 }

--- a/src/tests/testData/loadData.js
+++ b/src/tests/testData/loadData.js
@@ -35,7 +35,8 @@ function loadTestData(filepath, tableName) {
 
         for (const key in csvData[i]) {
           if (csvData[i][key] === '') continue;
-          params.Item[key] = {S: csvData[i][key]};
+          if (csvData[i][key] == '{}') params.Item[key] = {M: {}};
+          else params.Item[key] = {S: csvData[i][key]};
         }
 
         dynamoDb.putItem(params, function(err, data) {

--- a/src/transcribe/transcription.js
+++ b/src/transcribe/transcription.js
@@ -1,0 +1,25 @@
+/*
+transription.js
+
+Handles AWS transcribe start transcription services
+*/
+
+const config = require('../../config.js');
+const AWS = require('aws-sdk');
+AWS.config.update(config.awsTranscribeConfig);
+const transcribeService = new AWS.TranscribeService();
+
+
+module.exports.startTranscription = async (mediaFileLoaction) => {
+  console.log('transcription started');
+  const filename = mediaFileLoaction.split('/').pop();
+  const transcribeConfig = config.awsTranscriptionJob;
+  transcribeConfig['Media']['MediaFileUri'] = mediaFileLoaction;
+  transcribeConfig['TranscriptionJobName'] = filename;
+
+  transcribeService.startTranscriptionJob(transcribeConfig, function(err, data) {
+    // TODO: Add error/success responses
+    if (err) console.log(err, err.stack);
+    else console.log(data);
+  });
+};

--- a/src/utils/errorMsg.js
+++ b/src/utils/errorMsg.js
@@ -21,6 +21,7 @@ exports.params = {
   LONGITUDE: 'longitude',
   ORGANIZERID: 'organizerId',
   EVENTSTATUS: 'eventStatus',
+  AWSSERVER: 'backendServer',
 };
 
 // error messages
@@ -44,4 +45,5 @@ exports.messages = {
   EVENT_NOT_AT_LOCATION: 'User is too far away from event location',
   ORGANIZERID_NOT_FOUND: 'Organizer Id given cannot be found',
   EVENTSTATUS_INVALID: 'Event status must be approved, rejected, or pending',
+  AWS_SERVICE_ERROR: 'AWS service error has occurred',
 };

--- a/src/utils/errorMsg.js
+++ b/src/utils/errorMsg.js
@@ -21,7 +21,8 @@ exports.params = {
   LONGITUDE: 'longitude',
   ORGANIZERID: 'organizerId',
   EVENTSTATUS: 'eventStatus',
-  AWSSERVER: 'backendServer',
+  S3SERVICE: 's3Service',
+  TRANSCRIBESERVICE: 'transcriptionService',
 };
 
 // error messages

--- a/src/utils/errorMsg.js
+++ b/src/utils/errorMsg.js
@@ -23,6 +23,7 @@ exports.params = {
   EVENTSTATUS: 'eventStatus',
   S3SERVICE: 's3Service',
   TRANSCRIBESERVICE: 'transcriptionService',
+  FILE: 'file',
 };
 
 // error messages
@@ -48,4 +49,5 @@ exports.messages = {
   EVENTSTATUS_INVALID: 'Event status must be approved, rejected, or pending',
   AWS_SERVICE_ERROR: 'AWS service error has occurred',
   EVENT_ORGANIZER_ERROR: 'Must be logged in as event organizer to upload',
+  EVENT_FILENAME_UNIQUE: 'Event filenames must be unique',
 };

--- a/src/utils/errorMsg.js
+++ b/src/utils/errorMsg.js
@@ -47,4 +47,5 @@ exports.messages = {
   ORGANIZERID_NOT_FOUND: 'Organizer Id given cannot be found',
   EVENTSTATUS_INVALID: 'Event status must be approved, rejected, or pending',
   AWS_SERVICE_ERROR: 'AWS service error has occurred',
+  EVENT_ORGANIZER_ERROR: 'Must be logged in as event organizer to upload',
 };

--- a/src/utils/s3.js
+++ b/src/utils/s3.js
@@ -7,7 +7,9 @@ Handles AWS S3 services
 const config = require('../../config.js');
 const AWS = require('aws-sdk');
 const s3Config = config.awsConfig;
-s3Config['endpoint'] = config.awsS3.endpoint;
+const protocol = config.awsS3.protocol;
+const domain = config.awsS3.domain;
+s3Config['endpoint'] = `${protocol}://${domain}`;
 AWS.config.update(s3Config);
 const s3 = new AWS.S3();
 

--- a/src/utils/s3.js
+++ b/src/utils/s3.js
@@ -7,11 +7,9 @@ Handles AWS S3 services
 const config = require('../../config.js');
 const AWS = require('aws-sdk');
 const s3Config = config.awsConfig;
-// s3Config['endpoint'] = config.awsS3.endpoint;
+s3Config['endpoint'] = config.awsS3.endpoint;
 AWS.config.update(s3Config);
 const s3 = new AWS.S3();
-
-const transcribe = require('./transcription.js');
 
 module.exports.s3Upload = async (filename, eventId, fileStream) => {
   const params = {
@@ -20,18 +18,16 @@ module.exports.s3Upload = async (filename, eventId, fileStream) => {
     Key: `${eventId}-${filename}`,
   };
 
-  await s3.upload(params, function(err, data) {
-    if (err) {
-      console.log(err, err.stack);
-      return {success: false, msg: err};
-    } else {
-      // upload successful and start transcription
-      console.log(data);
-      const fileLocation = data['Location'];
-      transcribe.startTranscription(fileLocation);
-      return {success: true, msg: data};
-    }
+  return new Promise((resolve, reject) => {
+    s3.upload(params, function(err, data) {
+      if (err) {
+        console.log(err, err.stack);
+        return reject(err);
+      } else {
+        // upload successful
+        console.log(data);
+        return resolve(data);
+      }
+    });
   });
-
-  // return {success: true};
 };

--- a/src/utils/s3.js
+++ b/src/utils/s3.js
@@ -1,0 +1,27 @@
+/*
+s3.js
+
+Handles AWS S3 services
+*/
+
+const config = require('../../config.js');
+const AWS = require('aws-sdk');
+const s3Config = config.awsConfig;
+s3Config['endpoint'] = config.awsS3.endpoint;
+console.log(s3Config);
+AWS.config.update(s3Config);
+const s3 = new AWS.S3();
+
+
+module.exports.s3Upload = async (filename, eventId, fileStream) => {
+  console.log('s3 upload');
+  const params = {
+    Bucket: config.awsS3.uploadBucket,
+    Body: fileStream,
+    Key: `${eventId}-${filename}`,
+  };
+  s3.upload(params, function(err, data) {
+    if (err) console.log(err, err.stack);
+    else console.log(data);
+  });
+};

--- a/src/utils/s3.js
+++ b/src/utils/s3.js
@@ -7,21 +7,31 @@ Handles AWS S3 services
 const config = require('../../config.js');
 const AWS = require('aws-sdk');
 const s3Config = config.awsConfig;
-s3Config['endpoint'] = config.awsS3.endpoint;
-console.log(s3Config);
+// s3Config['endpoint'] = config.awsS3.endpoint;
 AWS.config.update(s3Config);
 const s3 = new AWS.S3();
 
+const transcribe = require('./transcription.js');
 
 module.exports.s3Upload = async (filename, eventId, fileStream) => {
-  console.log('s3 upload');
   const params = {
     Bucket: config.awsS3.uploadBucket,
     Body: fileStream,
     Key: `${eventId}-${filename}`,
   };
-  s3.upload(params, function(err, data) {
-    if (err) console.log(err, err.stack);
-    else console.log(data);
+
+  await s3.upload(params, function(err, data) {
+    if (err) {
+      console.log(err, err.stack);
+      return {success: false, msg: err};
+    } else {
+      // upload successful and start transcription
+      console.log(data);
+      const fileLocation = data['Location'];
+      transcribe.startTranscription(fileLocation);
+      return {success: true, msg: data};
+    }
   });
+
+  // return {success: true};
 };

--- a/src/utils/transcription.js
+++ b/src/utils/transcription.js
@@ -11,9 +11,7 @@ transcribeConfig['endpoint'] = config.awsTranscribeConfig.endpoint;
 AWS.config.update(transcribeConfig);
 const transcribeService = new AWS.TranscribeService();
 
-
 module.exports.startTranscription = async (mediaFileLoaction) => {
-  console.log('transcription started');
   const filename = mediaFileLoaction.split('/').pop();
   const transcribeConfig = config.awsTranscriptionJob;
   transcribeConfig['Media']['MediaFileUri'] = mediaFileLoaction;

--- a/src/utils/transcription.js
+++ b/src/utils/transcription.js
@@ -7,7 +7,9 @@ Handles AWS transcribe start transcription services
 const config = require('../../config.js');
 const AWS = require('aws-sdk');
 const transcribeConfig = config.awsConfig;
-transcribeConfig['endpoint'] = config.awsTranscribeConfig.endpoint;
+const protocol = config.awsTranscribeConfig.protocol;
+const domain = config.awsTranscribeConfig.domain;
+transcribeConfig['endpoint'] = `${protocol}://${domain}`;
 AWS.config.update(transcribeConfig);
 const transcribeService = new AWS.TranscribeService();
 
@@ -24,7 +26,10 @@ module.exports.startTranscription = async (mediaFileLoaction) => {
         return reject(err);
       } else {
         console.log(data);
-        return resolve(data);
+        // transcriptLocation
+        const transcriptLocation =
+          `${protocol}://${transcribeConfig['OutputBucketName']}.${domain}/${filename}`;
+        return resolve(transcriptLocation);
       }
     });
   });

--- a/src/utils/transcription.js
+++ b/src/utils/transcription.js
@@ -17,9 +17,15 @@ module.exports.startTranscription = async (mediaFileLoaction) => {
   transcribeConfig['Media']['MediaFileUri'] = mediaFileLoaction;
   transcribeConfig['TranscriptionJobName'] = filename;
 
-  transcribeService.startTranscriptionJob(transcribeConfig, function(err, data) {
-    // TODO: Add error/success responses
-    if (err) console.log(err, err.stack);
-    else console.log(data);
+  return new Promise((resolve, reject) => {
+    transcribeService.startTranscriptionJob(transcribeConfig, function(err, data) {
+      if (err) {
+        console.log(err, err.stack);
+        return reject(err);
+      } else {
+        console.log(data);
+        return resolve(data);
+      }
+    });
   });
 };

--- a/src/utils/transcription.js
+++ b/src/utils/transcription.js
@@ -6,7 +6,9 @@ Handles AWS transcribe start transcription services
 
 const config = require('../../config.js');
 const AWS = require('aws-sdk');
-AWS.config.update(config.awsTranscribeConfig);
+const transcribeConfig = config.awsConfig;
+transcribeConfig['endpoint'] = config.awsTranscribeConfig.endpoint;
+AWS.config.update(transcribeConfig);
 const transcribeService = new AWS.TranscribeService();
 
 


### PR DESCRIPTION
Completed: Accepting a file from a REST endpoint and uploading this file to s3. After the file is uploaded to s3, AWS transcribe will run off the uploaded s3 file. The resulting transcript is put in a separate s3 bucket.

To run: 

config.js needs to have `awsConfig`, `awsS3`, `awsTranscribeConfig`, and `awsTranscriptionJob` filled in (most can be copied from the config.sample.js. Get the accessKey and secretAccessKey from AWS. 

POST /api/event/upload
form-data
file (local mp3 file)
eventsId (eventId string)

You will see the results in s3 bucket location specified in config.js and the resulting transcription in AWS transcribe.

TODO: grab resulting transcription for front-end (will be a different PR)