### PR TITLE
Feature transcript status

### DIFF
--- a/server.js
+++ b/server.js
@@ -72,6 +72,7 @@ app.use(function(req, res, next) {
 require('./src/routes/index.js')(app);
 require('./src/routes/accounts.router.js')(app);
 require('./src/routes/events.router.js')(app);
+require('./src/routes/transcripts.router.js')(app);
 
 // listen for requests
 app.listen(port, () => {

--- a/src/controllers/emailHelper.js
+++ b/src/controllers/emailHelper.js
@@ -28,3 +28,12 @@ module.exports.sendEventStatusEmail = (email, name, status) => {
        \n Best,\nPinocchio`
   );
 };
+
+module.exports.sendTranscriptCompleteEmail = (email, filename) => {
+  sendMail(
+      email,
+      `Pinocchio - Your transcript for ${filename} is ready!`,
+      `Please log into Pinocchio to view your transcript online!
+       \n Best,\nPinocchio`
+  );
+};

--- a/src/controllers/events.controller.js
+++ b/src/controllers/events.controller.js
@@ -315,15 +315,16 @@ exports.upload = async (req, res, next) => {
           // upload successful and start transcription
             const fileLoaction = data['Location'];
             transcribe.startTranscription(fileLoaction)
-                .then((transcriptLocation) => {
+                .then((transcriptInfo) => {
                 // transcription job started successfully
-
                   // update event transcripts
-                  eventTranscripts[filename] = {
-                    location: transcriptLocation,
-                  };
+                  eventTranscripts[filename] = transcriptInfo;
                   dynamoDb.updateEvent(eventsId,
                       organizerId, 'transcripts', eventTranscripts);
+
+                  // update transcripts table
+                  dynamoDb.putTranscripts(transcriptInfo['TranscriptionJobName'],
+                      eventsId, filename);
 
                   uploadedFiles.push(filename);
 

--- a/src/controllers/transcripts.controller.js
+++ b/src/controllers/transcripts.controller.js
@@ -1,0 +1,101 @@
+/*
+controller for transcripts
+*/
+
+const dynamoDb = require('../models/dynamoDbWrapper.js');
+const transcribe = require('../utils/transcription.js');
+
+const responseMsg = require('../utils/responseMsg');
+const errorMsg = require('../utils/errorMsg');
+const {transcriptionStatuses} = require('../utils/constants');
+const {sendTranscriptCompleteEmail} = require('./emailHelper');
+
+// This endpoint is meant to be hit by a cron job to determine
+// if the pending transcripts are finished. If they are finished,
+// an email notification will be sent to the organizer and the eventsTable
+// transcription status will be updated.
+exports.update = async (req, res, next) => {
+  // get currently pending transcripts
+  const pendingTranscripts = await dynamoDb.getTranscripts();
+  if (!pendingTranscripts.success) return res.status(500).json(pendingTranscripts);
+  else {
+    if (pendingTranscripts.data.length > 0) {
+      // completedTranscripts will store all the
+      // transcripts associated with an eventId.
+      // This is to only do one query to update all
+      // the transcripts in a single eventId in the
+      // eventsTable.
+      const completedTranscripts = {};
+      for (transcripts of pendingTranscripts.data) {
+        const transcriptJobName = transcripts.transcriptJobName;
+        const eventsId = transcripts.eventsId;
+        const filename = transcripts.filename;
+        await transcribe.getTranscriptionJob(transcriptJobName)
+            .then((transcriptInfo) => {
+            // successfully got transcription job
+              const transcriptStatus = transcriptInfo['TranscriptionJobStatus'];
+              if (transcriptStatus == transcriptionStatuses.COMPLETED) {
+                const tmp = {
+                  filename: filename,
+                  transcriptDetails: transcriptInfo,
+                };
+                // transcript is completed
+                if (eventsId in completedTranscripts) {
+                  completedTranscripts[eventsId].push(tmp);
+                } else {
+                  completedTranscripts[eventsId] = [tmp];
+                }
+                // delete from transcriptsTable
+                dynamoDb.deleteTranscripts(transcriptJobName);
+              }
+            })
+            .catch((err) => {
+              // transcription service error
+              return res.status(500).json(responseMsg.error(errorMsg.params.TRANSCRIBESERVICE,
+                  errorMsg.messages.AWS_SERVICE_ERROR));
+            });
+      }
+      // update transcripts in eventsTable
+      if (completedTranscripts.length != 0) {
+        for (const eventsId in completedTranscripts) {
+          if (completedTranscripts.hasOwnProperty(eventsId)) {
+            const eventDetails = await dynamoDb.getEvents(eventsId);
+            if (!eventDetails.success) return res.status(500).json(eventDetails);
+            else {
+              // original event transcripts
+              const eventTranscripts = eventDetails.data[0].transcripts;
+              const organizerId = eventDetails.data[0].organizerId;
+
+              // get organizer email
+              const userExists = await dynamoDb.getUser(organizerId);
+              let organizerEmail= '';
+              if (!userExists.success) return res.status(500).json(userExists);
+              if (userExists.data.length > 0) {
+                // user exists
+                organizerEmail = userExists.data[0].email;
+              }
+
+              // recently updated transcripts
+              const completedEventTranscripts = completedTranscripts[eventsId];
+
+              // iterate through updated status transcripts
+              for (eventTranscript of completedEventTranscripts) {
+                const filename = eventTranscript.filename;
+                if (filename in eventTranscripts) {
+                  // replace pending transcript info with new info
+                  eventTranscripts[filename] = eventTranscript.transcriptDetails;
+
+                  // send email notification
+                  sendTranscriptCompleteEmail(organizerEmail, filename);
+                }
+              }
+              // update the eventId completed transcripts
+              dynamoDb.updateEvent(eventsId, organizerId, 'transcripts', eventTranscripts);
+            }
+          }
+        }
+      }
+    }
+    return res.json(responseMsg.success({}));
+  }
+};

--- a/src/dynamodb/createTables.js
+++ b/src/dynamodb/createTables.js
@@ -30,3 +30,4 @@ function createTable(tableJson) {
 // create all dynamo tables
 createTable(require('./jsons/usersTable.json'));
 createTable(require('./jsons/eventsTable.json'));
+createTable(require('./jsons/transcriptsTable.json'));

--- a/src/dynamodb/deleteTables.js
+++ b/src/dynamodb/deleteTables.js
@@ -34,3 +34,6 @@ deleteTable({
 deleteTable({
   TableName: require('./jsons/eventsTable.json').TableName,
 });
+deleteTable({
+  TableName: require('./jsons/transcriptsTable.json').TableName,
+});

--- a/src/dynamodb/jsons/transcriptsTable.json
+++ b/src/dynamodb/jsons/transcriptsTable.json
@@ -1,0 +1,19 @@
+{
+  "TableName": "transcriptsTable",
+  "KeySchema": [
+    {
+      "AttributeName": "transcriptJobName",
+      "KeyType": "HASH"
+    }
+  ],
+  "AttributeDefinitions": [
+    {
+      "AttributeName": "transcriptJobName",
+      "AttributeType": "S"
+    }
+  ],
+  "ProvisionedThroughput": {
+    "ReadCapacityUnits": 5,
+    "WriteCapacityUnits": 5
+  }
+}

--- a/src/models/dynamoDbWrapper.js
+++ b/src/models/dynamoDbWrapper.js
@@ -56,6 +56,18 @@ module.exports.updateData = async (tableName, args) => {
   }
 };
 
+module.exports.deleteData = async (tableName, args) => {
+  try {
+    const params = {TableName: tableName, ...args};
+    await dynamoDb.delete(params).promise();
+    return {success: true};
+  } catch (err) {
+    console.error('error when deleting data - ', args);
+    console.error(err);
+    return {success: false, ...err};
+  }
+};
+
 // generate unique ID based on UUID4
 module.exports.generateID = () => {
   return uuidv4();
@@ -168,4 +180,26 @@ module.exports.updateEvent = async (eventsId, organizerId, key, value) => {
     ReturnValues: 'UPDATED_NEW',
   };
   return await this.updateData('eventsTable', args);
+};
+
+module.exports.getTranscripts = async () => {
+  return await this.scanData('transcriptsTable', {});
+};
+
+module.exports.putTranscripts = async (jobName, eventsId, filename) => {
+  const item = {
+    transcriptJobName: jobName,
+    eventsId: eventsId,
+    filename: filename,
+  };
+  return await this.putData('transcriptsTable', item);
+};
+
+module.exports.deleteTranscripts = async (jobName) => {
+  const args = {
+    Key: {
+      transcriptJobName: jobName,
+    },
+  };
+  return await this.deleteData('transcriptsTable', args);
 };

--- a/src/routes/transcripts.router.js
+++ b/src/routes/transcripts.router.js
@@ -1,0 +1,29 @@
+/*
+/api/transcripts routes; This will handle all transcripts related api calls.
+*/
+
+module.exports = (app) => {
+  const transcripts = require('../controllers/transcripts.controller.js');
+
+  /**
+     * @swagger
+     * /api/transcripts/update:
+     *  get:
+     *      tags:
+     *          - Transcripts
+     *      name: update transcript status
+     *      summary: Update status for pending transcriptions
+     *      produces:
+     *          - application/json
+     *      consumes:
+     *          - application/x-www-form-urlencoded
+     *      responses:
+     *          '200':
+     *              description: transcripts updated
+     *          '500':
+     *              description: internal server error
+     *
+     */
+
+  app.get('/api/transcripts/update', transcripts.update);
+};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -81,3 +81,9 @@ exports.eventMessage = {
   'rejected': `Your event has been rejected. Please login to Pinocchio and select your event for\
   more details.`,
 };
+
+exports.transcriptionStatuses = {
+  IN_PROGRESS: 'IN_PROGRESS',
+  FAILED: 'FAILED',
+  COMPLETED: 'COMPLETED',
+};

--- a/src/utils/transcription.js
+++ b/src/utils/transcription.js
@@ -26,10 +26,26 @@ module.exports.startTranscription = async (mediaFileLoaction) => {
         return reject(err);
       } else {
         console.log(data);
-        // transcriptLocation
-        const transcriptLocation =
-          `${protocol}://${transcribeConfig['OutputBucketName']}.${domain}/${filename}`;
-        return resolve(transcriptLocation);
+        const transcriptInfo = data['TranscriptionJob'];
+        return resolve(transcriptInfo);
+      }
+    });
+  });
+};
+
+module.exports.getTranscriptionJob = async (transcriptionJob) => {
+  const params = {
+    TranscriptionJobName: transcriptionJob,
+  };
+
+  return new Promise((resolve, reject) => {
+    transcribeService.getTranscriptionJob(params, function(err, data) {
+      if (err) {
+        console.log(err);
+        return reject(err);
+      } else {
+        console.log(data);
+        return resolve(data.TranscriptionJob);
       }
     });
   });


### PR DESCRIPTION
**Dependency: #25 **

### Completed
- `/api/transcripts/update'

There is no callback to wait for a transcription to be completed (in order to send an email notification to organizer)

This endpoint is meant to be used internally to be continuously hit from a `cron` job. Uploading a transcription will have the following flow:

1. Organizer uploads transcript(s) using `/api/events/upload`
- Transcripts are stored in S3 and are started in AWS transcribe.
- `eventsTable` is updated with the transcripts uploaded with `PENDING` status. 
- `transcriptsTable` is updated with the transcript(s) uploaded as `PENDING` status.
2. A `cron` job will hit `/api/transcripts/update`
-  Iterate through all PENDING transcripts in transcriptsTable. Send a get transcript request to AWS transcribe. 
- If the transcription is completed, remove from `transcriptsTable`; send email to organizer; update `eventsTable` with completed transcript information
- Else: nothing happens

This will be a prereq for getting a completed transcription.